### PR TITLE
fix/termina-input

### DIFF
--- a/.setup/setup.sh
+++ b/.setup/setup.sh
@@ -49,7 +49,7 @@ fi
 # Ensure main branch is checked out
 echo
 echo -ne "${YELLOW}Specify the branch to checkout [main]: ${NC}"
-read BRANCH_NAME
+read BRANCH_NAME < /dev/tty
 echo
 BRANCH_NAME=${BRANCH_NAME:-main}
 git checkout "$BRANCH_NAME"

--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ The setup script includes functions for installing all common packages and adds 
 1. Make sure you are in the directory where you want the repository to be cloned.
 2. Open the Chrome OS Linux terminal, then copy and paste the following text to download and run the setup scripts.
 ```bash
-bash <(curl -sS https://raw.githubusercontent.com/neilgfoster/base/main/.setup/setup.sh) -o=neilgfoster -r=cros-base
+bash <(curl -sS https://raw.githubusercontent.com/neilgfoster/cros-base/main/.setup/setup.sh) -o=neilgfoster -r=cros-base
 ```


### PR DESCRIPTION
This pull request updates the setup documentation and script to improve usability and correctness. The most important changes are grouped below:

Documentation update:

* Updated the setup instructions in `README.md` to reference the correct GitHub repository URL (`neilgfoster/cros-base` instead of `neilgfoster/base`).

Setup script improvement:

* Modified `.setup/setup.sh` to explicitly read the branch name input from `/dev/tty`, ensuring interactive input works correctly even when the script is run via process substitution.