### PR TITLE
fix/missing-folders

### DIFF
--- a/.setup/setup.sh
+++ b/.setup/setup.sh
@@ -39,7 +39,7 @@ if [ "${DEVCONTAINER}" != "true" ]; then
   # Navigate to the correct directory and clone
   if [[ -n "$ORG" && -n "$REPO" ]]; then
     sudo apt install -y git
-    folders=(".setup" "base" "$REPO" "$ORG")
+    folders=(".setup" "base" "cros-base" "cros-setup" "$REPO" "$ORG")
     for folder in "${folders[@]}"; do
       if [ "$(basename "$PWD")" = "$folder" ]; then
         cd ..


### PR DESCRIPTION
This pull request makes a small update to the setup script by expanding the list of directories considered during the cloning process. This change ensures that additional folders are accounted for when navigating and preparing the environment.

* Added `cros-base` and `cros-setup` to the list of folders checked during setup in `.setup/setup.sh`.